### PR TITLE
Apache2log

### DIFF
--- a/config/parameters.yml.dist
+++ b/config/parameters.yml.dist
@@ -6,6 +6,7 @@ parameters:
     beginLine: 0
     numberOfLine: 300
     logParserClass: \Log2Test\CbmLogParser
+    logFormat: '%h %l %u %t \"%r\" %>s %b'
     extensions_allowed:
         - php
         - html

--- a/lib/Apache2LogParser.php
+++ b/lib/Apache2LogParser.php
@@ -2,18 +2,85 @@
 
 namespace Log2Test;
 
+use Kassner\LogParser as KassnerLogParser;
+use Log2Test\LogParser;
+
+
 class Apache2LogParser extends LogParser
 {
+    /**
+     * Apache LogParser
+     *
+     * @var KassnerLogParser
+     */
+    protected $kassnerLogParser;
 
-    public function __construct()
+    /**
+     * @var
+     */
+    protected $logFormat;
+
+    /*
+     * {@inheritDoc}
+     */
+    public function __construct(ConfigParser $configParser)
     {
-        parent::__construct();
+        parent::__construct($configParser);
+        $this->setLogFormat($configParser->getValueFromKey('logFormat'));
+        $this->setKassnerLogParser(new \Kassner\LogParser\LogParser($this->getLogFormat()));
     }
 
     /*
-     * @inheritdoc
+     * {@inheritDoc}
      */
     public function parseOneLine($line)
     {
+        $kassnerParser = $this->getKassnerLogParser();
+        $parsedLine = $kassnerParser->parse($line);
+        if (isset($parsedLine->host) &&
+            isset($parsedLine->request) &&
+            in_array($parsedLine->host, $this->getHosts())) {
+            $requestConfig = explode(Constants::SPACE_CHAR, $parsedLine->request);
+            $path = $requestConfig[Constants::REQUEST_PATH];
+            $parsedUrl = parse_url($path);
+            $extension = pathinfo($parsedUrl['path'], PATHINFO_EXTENSION);
+            if (in_array($extension, $this->getExtensionsAllowed()))
+            {
+                $this->addTestToConfiguration($parsedLine->host, $path);
+            }
+        }
+    }
+
+
+    /**
+     * @return KassnerLogParser
+     */
+    public function getKassnerLogParser()
+    {
+        return $this->kassnerLogParser;
+    }
+
+    /**
+     * @param KassnerLogParser $kassnerLogParser
+     */
+    public function setKassnerLogParser($kassnerLogParser)
+    {
+        $this->kassnerLogParser = $kassnerLogParser;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLogFormat()
+    {
+        return $this->logFormat;
+    }
+
+    /**
+     * @param mixed $logFormat
+     */
+    public function setLogFormat($logFormat)
+    {
+        $this->logFormat = $logFormat;
     }
 }

--- a/lib/Apache2LogParser.php
+++ b/lib/Apache2LogParser.php
@@ -42,9 +42,10 @@ class Apache2LogParser extends LogParser
             in_array($parsedLine->host, $this->getHosts())) {
             $requestConfig = explode(Constants::SPACE_CHAR, $parsedLine->request);
             $path = $requestConfig[Constants::REQUEST_PATH];
+            $method = $requestConfig[Constants::REQUEST_METHOD];
             $parsedUrl = parse_url($path);
             $extension = pathinfo($parsedUrl['path'], PATHINFO_EXTENSION);
-            if (in_array($extension, $this->getExtensionsAllowed()))
+            if (Constants::METHOD_GET === $method && in_array($extension, $this->getExtensionsAllowed()))
             {
                 $this->addTestToConfiguration($parsedLine->host, $path);
             }

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -18,5 +18,34 @@ final class Constants
      */
     const BEGIN_LINE = 'beginLine';
 
+    /*
+     * Get Method
+     */
+    const METHOD_GET = 'GET';
+
+    /*
+     * Post Method
+     */
+    const METHOD_POST = 'POST';
+
+    /*
+     * Space Char
+     */
     const SPACE_CHAR = ' ';
+
+    /*
+     * Request Method (GET / PUT / POST...)
+     */
+    const REQUEST_METHOD = 0;
+
+    /*
+     * Request Path (/file.txt /page.php...)
+     */
+    const REQUEST_PATH = 1;
+
+    /*
+     * Request Version (HTTP/1.0
+     */
+    const REQUEST_HTTP_VERSION = 2;
+
 }

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -37,14 +37,13 @@ class Utils
      */
     public static function contains($str, array $values, $addSpaces = false)
     {
-        foreach($values as $value) {
+        foreach ($values as $value) {
             if (true === $addSpaces) {
-                if (stripos($str, Constants::SPACE_CHAR . $value . Constants::SPACE_CHAR) !== false) {
+                if (stripos($str, Constants::SPACE_CHAR . $value . Constants::SPACE_CHAR . Constants::METHOD_GET) !== false) {
 
                     return $value;
                 }
-            } else
-            if (stripos($str, $value) !== false) {
+            } elseif (stripos($str, $value) !== false) {
 
                 return $value;
             }

--- a/log/test_v2.log
+++ b/log/test_v2.log
@@ -1,0 +1,4 @@
+www.epitech.fr - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.php HTTP/1.0" 200 2326
+127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326
+www.epitech.fr - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb44.html HTTP/1.0" 200 2326
+127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326


### PR DESCRIPTION
Allowing Apache2 parsing throw KassnerLogParser. 
User can now give his apache2 Log Format on his parameter.yml file.
Only gernerating test on GET calls
