### PR TITLE
use official regex to generate class name

### DIFF
--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -16,11 +16,19 @@ trait Utils
     public static function urlToString($url)
     {
         $cleanedString = str_replace(
-            array(' ', 'http://', 'www.', '-'), '',
+            array('http://', 'www.'), 
+            '', 
             $url
         );
-        $cleanedString = preg_replace('/[^A-Za-z0-9\-]/', '', $cleanedString);
 
+        /**
+          * http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class
+          * A valid class name starts with a letter or underscore, followed by any number of letters, numbers, or underscores
+          *
+          * To replace all characters not match : can use a negated character class (using ^ at the beginning of the class)
+          */
+
+        $cleanedString = preg_replace('/[^a-zA-Z_\\x7f-\\xff][^a-zA-Z0-9_\\x7f-\\xff]*/', '_', 'dev-webservice-caradisiac.yteboul.caradisiac.dev', -1);
         return $cleanedString;
     }
 

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -28,7 +28,7 @@ trait Utils
           * To replace all characters not match : can use a negated character class (using ^ at the beginning of the class)
           */
 
-        $cleanedString = preg_replace('/[^a-zA-Z_\\x7f-\\xff][^a-zA-Z0-9_\\x7f-\\xff]*/', '_', 'dev-webservice-caradisiac.yteboul.caradisiac.dev', -1);
+        $cleanedString = preg_replace('/[^a-zA-Z_\x7f-\xff][^a-zA-Z0-9_\x7f-\xff]*/', '', $cleanedString, -1);
         return $cleanedString;
     }
 


### PR DESCRIPTION
The class name can be any valid label, provided it is not a PHP reserved word. 
A valid class name starts with a letter or underscore, followed by any number of letters, numbers, or underscores. 
As a regular expression, it would be expressed thus: ^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$. 

http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class