### PR TITLE
use official regex to generate class name

### DIFF
--- a/features/main.feature
+++ b/features/main.feature
@@ -3,11 +3,11 @@ Feature: Generate log2test Test in different stack
     Scenario: Log2Test generates PhpCurl test from logFile
         Given apache2 Log File log/test.log
         When I generate "curl" test
-        Then "generated/curl/Shop2toutlocal/testSuite1/Shop2toutlocalFrom0To30Test.php" was generated
-        And "generated/curl/Shop2toutlocal/testSuite1/Shop2toutlocalFrom0To30Test.php" file_sha1 is equal to "95f51547889321f7717206a66d4678c751871312"
+        Then "generated/curl/Shoptoutlocal/testSuite1/ShoptoutlocalFrom0To30Test.php" was generated
+        And "generated/curl/Shoptoutlocal/testSuite1/ShoptoutlocalFrom0To30Test.php" file_sha1 is equal to "789df1ea1a1f8eac9c1478c479caa8c57d075b31"
 
     Scenario: Log2Test generates PhpunitSelenium test from logFile
         Given apache2 Log File log/test.log
         When I generate "phpunit_selenium" test
-        Then "generated/phpunit_selenium/Shop2toutlocal/testSuite1/Shop2toutlocalFrom0To30Test.php" was generated
-        And "generated/phpunit_selenium/Shop2toutlocal/testSuite1/Shop2toutlocalFrom0To30Test.php" file_sha1 is equal to "1af113cd03352ed6b3ea7e34cb2874d48ef94e12"
+        Then "generated/phpunit_selenium/Shoptoutlocal/testSuite1/ShoptoutlocalFrom0To30Test.php" was generated
+        And "generated/phpunit_selenium/Shoptoutlocal/testSuite1/ShoptoutlocalFrom0To30Test.php" file_sha1 is equal to "cbf4a6aeb5cf8a44c287ffcead973fdb2ff0285a"

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -16,11 +16,19 @@ trait Utils
     public static function urlToString($url)
     {
         $cleanedString = str_replace(
-            array(' ', 'http://', 'www.', '-'), '',
+            array('http://', 'www.'), 
+            '', 
             $url
         );
-        $cleanedString = preg_replace('/[^A-Za-z0-9\-]/', '', $cleanedString);
 
+        /**
+          * http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class
+          * A valid class name starts with a letter or underscore, followed by any number of letters, numbers, or underscores
+          *
+          * To replace all characters not match : can use a negated character class (using ^ at the beginning of the class)
+          */
+
+        $cleanedString = preg_replace('/[^a-zA-Z_\\x7f-\\xff][^a-zA-Z0-9_\\x7f-\\xff]*/', '_', 'dev-webservice-caradisiac.yteboul.caradisiac.dev', -1);
         return $cleanedString;
     }
 

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -28,7 +28,7 @@ trait Utils
           * To replace all characters not match : can use a negated character class (using ^ at the beginning of the class)
           */
 
-        $cleanedString = preg_replace('/[^a-zA-Z_\\x7f-\\xff][^a-zA-Z0-9_\\x7f-\\xff]*/', '_', 'dev-webservice-caradisiac.yteboul.caradisiac.dev', -1);
+        $cleanedString = preg_replace('/[^a-zA-Z_\x7f-\xff][^a-zA-Z0-9_\x7f-\xff]*/', '', $cleanedString, -1);
         return $cleanedString;
     }
 


### PR DESCRIPTION
The class name can be any valid label, provided it is not a PHP reserved word.
A valid class name starts with a letter or underscore, followed by any number of letters, numbers, or underscores.
As a regular expression, it would be expressed thus: ^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$.

http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class